### PR TITLE
fix: final review regex

### DIFF
--- a/website/app/pages/final-review/[id].vue
+++ b/website/app/pages/final-review/[id].vue
@@ -31,7 +31,7 @@ const mode = computed(() => {
     return undefined
   }
 
-  const cluster = id.value.match(/c(\d+)/i)
+  const cluster = id.value.match(/^c(\d+)$/i)
 
   if (!cluster || !cluster[1]) {
     return {


### PR DESCRIPTION
## fix

* final review regex wasn't anchored to start/end of string so it matched strings `rfc1234` (note that it has `c1234` in it like a cluster) rather than just `c1234`