### PR TITLE
fix: add a link to contact.md

### DIFF
--- a/website/content/about/contact.md
+++ b/website/content/about/contact.md
@@ -2,3 +2,5 @@
 
 - RFC Production Center (RPC): [rfc-editor@rfc-editor.org](mailto:rfc-editor@rfc-editor.org)
 - To report a technical problem with this site: [support@ietf.org](mailto:support@ietf.org)
+
+See also [the contact page of www.rfc-editor.org](https://www.rfc-editor.org/about/contact).


### PR DESCRIPTION
add link to full contact page on main site